### PR TITLE
Fix radio input errors

### DIFF
--- a/Interpreter/Html/Form.php
+++ b/Interpreter/Html/Form.php
@@ -355,13 +355,29 @@ class Form extends Generic implements \Hoa\Xyl\Element\Executable {
 
                     foreach($names[$index] as $element) {
 
-                        $handle = $element->isValid($revalid, $datum);
+                        $postValidation = !(   ($element instanceof Input)
+                                            && ('radio' === strtolower($element->readAttribute('type'))));
+                        $handle = $element->isValid($revalid, $datum, $postValidation);
 
                         if(true === $handle)
                             $element->setValue($datum);
 
                         $validation[$index] = $validation[$index] || $handle;
                     }
+
+                    if(false === $validation[$index])
+                        foreach($names[$index] as $element) {
+
+                            $postValidation = !(   ($element instanceof Input)
+                                                && ('radio' === strtolower($element->readAttribute('type'))));
+
+                            if(false === $postValidation)
+                                static::postValidation(
+                                    $element->getValidity(),
+                                    $datum,
+                                    $element
+                                );
+                        }
 
                     unset($names[$index]);
                     unset($flat[$index]);
@@ -407,12 +423,12 @@ class Form extends Generic implements \Hoa\Xyl\Element\Executable {
             */
         }
 
-        foreach($names as $name => $element)
-            foreach($element as $el)
-                if((   $el instanceof Input
-                    || $el instanceof Textarea
-                    || $el instanceof Select)
-                   && true === $el->attributeExists('required'))
+        foreach($names as $name => $elements)
+            foreach($elements as $element)
+                if((   $element instanceof Input
+                    || $element instanceof Textarea
+                    || $element instanceof Select)
+                   && true === $element->attributeExists('required'))
                     $validation[$name] = false;
 
         $handle = &$this->_validity;

--- a/Interpreter/Html/Input.php
+++ b/Interpreter/Html/Input.php
@@ -181,11 +181,13 @@ class Input extends Generic {
      * Whether the input is valid or not.
      *
      * @access  public
-     * @param   bool   $revalid    Re-valid or not.
-     * @param   mixed  $value      Value to test.
+     * @param   bool   $revalid           Re-valid or not.
+     * @param   mixed  $value             Value to test.
+     * @param   bool   $postValidation    Run postvalidation or not.
      * @return  bool
      */
-    public function isValid ( $revalid = false, &$value ) {
+    public function isValid ( $revalid = false, &$value,
+                              $postValidation = true ) {
 
         if(false === $revalid && null !== $this->_validity)
             return $this->_validity;
@@ -198,6 +200,9 @@ class Input extends Generic {
 
             $this->_validity = false;
 
+            if(false === $postValidation)
+                return $this->_validity;
+
             return Form::postValidation($this->_validity, $value, $this);
         }
 
@@ -205,6 +210,9 @@ class Input extends Generic {
            || false !== strpos($value, "\r")) {
 
             $this->_validity = false;
+
+            if(false === $postValidation)
+                return $this->_validity;
 
             return Form::postValidation($this->_validity, $value, $this);
         }
@@ -216,6 +224,9 @@ class Input extends Generic {
             if(0 == @preg_match('#^' . $pattern . '$#u', $value, $_)) {
 
                 $this->_validity = false;
+
+                if(false === $postValidation)
+                    return $this->_validity;
 
                 return Form::postValidation($this->_validity, $value, $this);
             }
@@ -229,6 +240,9 @@ class Input extends Generic {
 
                 $this->_validity = false;
 
+                if(false === $postValidation)
+                    return $this->_validity;
+
                 return Form::postValidation($this->_validity, $value, $this);
             }
         }
@@ -236,6 +250,9 @@ class Input extends Generic {
         if(true === $this->attributeExists('readonly')) {
 
             $this->_validity = $value === $this->readAttribute('value');
+
+            if(false === $postValidation)
+                return $this->_validity;
 
             return Form::postValidation($this->_validity, $value, $this);
         }
@@ -376,6 +393,9 @@ class Input extends Generic {
                 $this->_validity = true;
         }
 
+        if(false === $postValidation)
+            return $this->_validity;
+
         return Form::postValidation($this->_validity, $value, $this);
     }
 
@@ -426,6 +446,17 @@ class Input extends Generic {
             return false;
 
         return $step;
+    }
+
+    /**
+     * Get validity.
+     *
+     * @access  public
+     * @return  bool
+     */
+    public function getValidity ( ) {
+
+        return $this->_validity;
     }
 }
 


### PR DESCRIPTION
Only one radio input is valid at a time. So all others (for the same name) are invalid and then throw an error. This patch fixes this behavior. We run the `postValidation` method manually for radio input if they are all invalid.
