### PR TITLE
Unset `theme` when unrouting `hoa://App…/Public`

### DIFF
--- a/Xyl.php
+++ b/Xyl.php
@@ -1458,10 +1458,13 @@ class          Xyl
                     $resource = $m[1];
                 }
 
-                return $router->unroute(
-                    $rule,
-                    ['theme' => $theme, 'resource' => $resource]
-                );
+                $variables = ['resource' => $resource];
+
+                if (!empty($theme)) {
+                    $variables['theme'] = $theme;
+                }
+
+                return $router->unroute($rule, $variables);
             }
 
             return $this->resolve($link, $late);


### PR DESCRIPTION
`hoa://Application/Public` links are transformed into the `@_resource` rule in the router. When unrouting, the `theme` variable is set even if empty. However, since https://github.com/hoaproject/Router/pull/33, unused variables are added as query strings in the generated unrouted URL, which is great! Except here because the `?theme=` empty query string is added everywhere (if `setTheme` has been called with an empty value and if the `@_resource` rule has been rewritten to remove the theme context).

So this patch removes the `theme` variable, if empty, from the list of variables given to the router for the unrouting of `hoa://Application/Public/`.