### PR TITLE
Add a way to validate form with multiple element with the same name (like checkbox or radio)

### DIFF
--- a/Interpreter/Html/Form.php
+++ b/Interpreter/Html/Form.php
@@ -304,10 +304,22 @@ class Form extends Generic implements Xyl\Element\Executable
         $elements   = $this->getElements();
         $names      = [];
         $validation = [];
+        $nameIterator = [];
 
         foreach ($elements as &$_element) {
             $_element = $this->getConcreteElement($_element);
             $name     = $_element->readAttribute('name');
+
+            $bracketPos = strpos($name, '[');
+            if(false !== $bracketPos) {
+
+                if(!array_key_exists($name, $nameIterator))
+                    $nameIterator[$name] = 0 ;
+                else
+                    $nameIterator[$name]++ ;
+
+                $name = substr($name,0,$bracketPos) . '[' . intval($nameIterator[$name]).']';
+            }
 
             if (!isset($names[$name])) {
                 $names[$name] = [];
@@ -315,7 +327,7 @@ class Form extends Generic implements Xyl\Element\Executable
 
             $names[$name][] = $_element;
         }
-
+        
         foreach ($data as $index => $datum) {
             if (!is_array($datum)) {
                 if (!isset($names[$index])) {
@@ -352,12 +364,6 @@ class Form extends Generic implements Xyl\Element\Executable
                 continue;
             }
 
-            $validation[$index] = false;
-
-            /*
-            print_r($flat);
-            print_r($validation);
-
             $remainder = array();
 
             foreach($datum as $key => &$value) {
@@ -375,10 +381,10 @@ class Form extends Generic implements Xyl\Element\Executable
                 $validation[$key] = $names[$key][0]->isValid($revalid, $value);
                 unset($flat[$key]);
                 unset($names[$key]);
+
+                continue;
             }
 
-            print_r($remainder);
-            */
         }
 
         foreach ($names as $name => $element) {


### PR DESCRIPTION
Restore an old piece of code and add a way to validate form with multiple element with the same name (like checkbox or radio).

We should be able now to do something like 

Form.xyl :
```xml
<?xml version="1.0" encoding="utf-8"?>

<document xmlns="http://hoa-project.net/xyl/xylophone">
  <title>Form</title>

  <form action="#" method="post" id="myForm">
    <p>Foo: <input type="text" name="foo" /></p>
    <p>Bar: <input type="text" name="bar" /></p>
    <p><input type="checkbox" name="baz[]" value="1" /></p>
    <p><input type="checkbox" name="baz[]" value="2" /></p>
    <p><input type="checkbox" name="baz[]" value="3" /></p>
    <p><input type="submit" /></p>
  </form>

  <ul>
    <li bind="?result" />
  </ul>
</document>
```
index.php :
```php
$xyl = new Hoa\Xyl(
    new Hoa\File\Read('Form.xyl'),
    new Hoa\Http\Response\Response(),
    new Hoa\Xyl\Interpreter\Html\Html()
);
$xyl->interprete();
$data = $xyl->getData();
$form = $xyl->getElement('myForm');

if(  true === $form->hasBeenSent()) {
        if (true === $form->isValid())
            $data->result = array_values($form->getData());
        else 
            $data->result = "not-valid";
}

$xyl->render();
```

It may also fix #10 and #24 

I'm not sure to use the cleaniest way to do that but it works :/